### PR TITLE
Enable power saving and notifications

### DIFF
--- a/.config/openbox/autostart
+++ b/.config/openbox/autostart
@@ -4,6 +4,10 @@ xrandr --output VGA-1 --mode 1920x1080 --rate 60
 
 xcompmgr &
 
+/usr/lib/notification-daemon/notification-daemon &
+
+gnome-settings-daemon &
+
 sh $HOME/.fehbg
 
 conky &

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ HINT: If you have issues with window placement on wrong monitor etc. check the
 ~/.config/openbox/rc.xml there is a placement section where you can specify
 where windows should spwan.
 
+### Power saving and miscellaneous settings
+To be able to configure power saving mode and other settings like fonts, keyboard, mouse and so on, you have to install some gnome dependencies.
+
+    sudo apt install gnome-control-center gnome-settings-daemon
+
 ### Terminal Emulator
 
 Terminator is a powerful terminal emulator written in python having useful
@@ -276,6 +281,14 @@ to the openbox rc.xml.
     #         <command>/usr/bin/gmrun</command>
     #     </action>
     # </keybind>
+
+### Notification PopUps
+
+You might want to get popups from your installed application during work.
+Just install the needed notification-daemon, which will be started during
+the next boot automatically.
+
+    sudo apt install notification-daemon
 
 ### Additional Software
 

--- a/activate_dotfiles
+++ b/activate_dotfiles
@@ -59,7 +59,7 @@ echo -e "${GREEN} done${RESET}"
 
 if [[ -L ~/.config/terminator ]]; then
     unlink ~/.config/terminator
-elif [[ -d ~/.conifg/terminator ]]; then
+elif [[ -d ~/.config/terminator ]]; then
     echo -e "${ORANGE}Found existing ~/.config/terminator folder creating backup to ~/.config/terminator${RESET}"
     mv ~/.config/terminator ~/.config/terminator.bak
 fi


### PR DESCRIPTION
This is enabling proper power saving with gnome-power-manager, configure by gnome-control-center (using gnome-settings-daemon) and notification with notification-daemon.

Also the symlinking of terminator got a bug which is fixed now.